### PR TITLE
when parsing "a" or "link" tag, check existence of href attribute

### DIFF
--- a/src/parsers/micro-rdfa-parser.js
+++ b/src/parsers/micro-rdfa-parser.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 function getPropValue (tagName, attribs, TYPE, PROP) {
   if (attribs[TYPE]) {
     return null
-  } else if (tagName === 'a' || tagName === 'link') {
+  } else if ((tagName === 'a' || tagName === 'link') && attribs.href) {
     return attribs.href.trim()
   } else if (attribs.content) {
     return attribs.content.trim()

--- a/test/resources/testPage.html
+++ b/test/resources/testPage.html
@@ -82,6 +82,6 @@
                     </span>
     Condition: <link property="itemCondition" href="http://schema.org/UsedCondition"/>Previously owned,
       in excellent condition
-    <link property="availability" href="http://schema.org/InStock"/>In stock! Order now!</span>
+    <link property="availability" content="http://schema.org/InStock"/>In stock! Order now!</span>
   </span>
 </div>


### PR DESCRIPTION
I ran into some html that used a 'content' attribute with the 'link' tag rather than 'href'. This caused the parsing to bail as it assumes 'href' exists whenever a tag is 'a' or 'link'.

A simple check that 'href' exists seems like the right fix. In the case a 'content' attribute is used, the tag content is correctly parsed. If the url information is simply missing, we would return null.

Test updated to include this case.